### PR TITLE
added drag and drop change state feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "blue-space-be-t",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "lucide-react": "^0.469.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -40,6 +43,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3534,6 +3586,11 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/turbo-stream": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "lucide-react": "^0.469.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -2,26 +2,49 @@ import {useContext, useState} from "react";
 import {CardType} from "../../types.ts";
 import {InfoCardModal} from "../modals/infoCardModal/infoCardModal.tsx";
 import {StatesContext} from "../../context/statesContext.tsx";
+import {useDraggable} from "@dnd-kit/core";
+import {GripVertical} from "lucide-react";
 
 export function Card({cardProps}: { cardProps: CardType }) {
     const {
         setSelectedCard,
     } = useContext(StatesContext)
-    
-    const [openInfoCardModal , setOpenInfoCardModal] = useState(false)
-    
+
+    const [openInfoCardModal, setOpenInfoCardModal] = useState(false)
+
+    const {attributes, listeners, setNodeRef, transform} = useDraggable({
+        id: cardProps.id,
+        data: {...cardProps}
+    })
+
+    const style = transform ?
+        {
+            opacity: 0.3
+        }
+        :
+        undefined
+
     return (
         <>
             <div
+                ref={setNodeRef}
+                style={style}
                 className="flex w-[98%] min-h-10 h-auto bg-white 
                 border shadow border-gray-400 px-2 py-2 text-ellipsis 
-                overflow-hidden rounded-lg cursor-pointer"
+                overflow-hidden rounded-lg cursor-pointer justify-between"
                 onClick={() => {
                     setSelectedCard(cardProps)
                     setOpenInfoCardModal(true)
                 }}
             >
                 <p>{cardProps.title}</p>
+                <div
+                    {...attributes}
+                    {...listeners}
+                    className={"hover:cursor-grab"}
+                >
+                    <GripVertical className={"text-gray-400"}/>
+                </div>
             </div>
             <InfoCardModal open={openInfoCardModal} setOpen={setOpenInfoCardModal}/>
         </>

--- a/src/components/state/state.tsx
+++ b/src/components/state/state.tsx
@@ -6,7 +6,7 @@ import {CardType, StateType} from "../../types.ts";
 import {StateOptionsModal} from '../modals/stateOptionsModal/stateOptionsModal.tsx';
 import {StatesContext} from '../../context/statesContext.tsx';
 import {NewCardModal} from '../modals/newCardModal/newCardModal.tsx';
-
+import {useDroppable} from "@dnd-kit/core";
 
 export function State({stateProps}: { stateProps: StateType }) {
 
@@ -15,8 +15,12 @@ export function State({stateProps}: { stateProps: StateType }) {
         handleRefreshState
     } = useContext(StatesContext)
 
+    const {setNodeRef} = useDroppable({
+        id: stateProps.id
+    });
+
     const [cards, setCards] = useState<CardType[]>([])
-    const [openNewCardModal ,setOpenNewCardModal] = useState(false)
+    const [openNewCardModal, setOpenNewCardModal] = useState(false)
     const [openStateOptionsModal, setOpenStateOptionsModal] = useState(false)
 
     useEffect(() => {
@@ -41,10 +45,11 @@ export function State({stateProps}: { stateProps: StateType }) {
                         <EllipsisVertical/>
                     </button>
                 </div>
-                <hr className="border-t border-gray-400 mt-2"/>
-                <div className={"flex flex-col"}>
+
+                <div ref={setNodeRef} className={"flex flex-col"}>
                     <div
-                        className="flex flex-col mt-2 mb-2 max-h-[500px] md:max-h-[530px] overflow-y-auto items-center gap-4">
+
+                        className="flex flex-col mt-2 mb-2 max-h-[500px] md:max-h-[530px] overflow-y-auto overflow-x-hidden items-center gap-4 transition-all">
                         {cards.length > 0 ? (
                             cards.map((card) => (
                                 <Card key={card.id} cardProps={card}/>

--- a/src/components/statesContainer/statesContainer.tsx
+++ b/src/components/statesContainer/statesContainer.tsx
@@ -2,17 +2,22 @@ import {State} from "../state/state.tsx";
 import {Plus} from "lucide-react";
 import {useContext, useEffect, useState} from "react";
 import {UserContext} from "../../context/userContext.tsx";
-import {StateType} from "../../types"
+import {CardType, defaultCardType, StateType} from "../../types"
 import {NewStateModal} from "../modals/newStateModal/newStateModal.tsx";
 import {StatesContext} from "../../context/statesContext.tsx";
+import {DndContext, DragEndEvent, DragStartEvent} from "@dnd-kit/core";
+import {DragOverlay} from "@dnd-kit/core";
+import {Card} from "../card/card.tsx";
 
 export function StatesContainer() {
 
     const [states, setStates] = useState<StateType[]>([])
     const {selectedProject} = useContext(UserContext)
-    const {refreshStateContainer} = useContext(StatesContext)
-    const [openNewStateModal , setOpenNewStateModal] = useState(false)
-    
+    const {refreshStateContainer, handleRefreshState} = useContext(StatesContext)
+    const [openNewStateModal, setOpenNewStateModal] = useState(false)
+    const [activeId, setActiveId] = useState<string | null>(null);
+    const [activeCard, setActiveCard] = useState<CardType>(defaultCardType)
+
     useEffect(() => {
         if (selectedProject.id === '') return
         fetch(`http://localhost:8080/api/state?project_id=${selectedProject.id}`)
@@ -21,31 +26,67 @@ export function StatesContainer() {
             .catch(error => console.log(error))
     }, [selectedProject.id, refreshStateContainer])
 
+    const handleDragEnd = async (event: DragEndEvent) => {
+        setActiveId(null);
+        const {active, over} = event
+        if (!over) return
+
+        const cardId = active.id as string
+        const stateId = over.id as string
+
+        await fetch(`http://localhost:8080/api/card/${cardId}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({state_id: stateId})
+        })
+            .then(response => response.json())
+            .then(() => {
+                handleRefreshState()
+            })
+            .catch(error => console.log(error))
+    }
+
+    function handleDragStart(event: DragStartEvent) {
+        const id = event.active.id as string;
+        const data = event.active.data.current as CardType
+        setActiveCard(data)
+        setActiveId(id);
+    }
+
     return (
         <>
-            <div className="flex flex-row mt-12 overflow-x-auto w-full h-[85%] ">
-                {states.length > 0 ? (
-                    states.map((state) => (
-                        <State key={state.id} stateProps={state}/>
-                    ))
-                ) : (
-                    <div className={"flex w-[90%] h-full items-center justify-center"}>
-                        <p className={"text-xl sm:text-2xl bg-gray-100 rounded-lg border-2 p-2"}>No states yet !</p>
-                    </div>
-                )}
+            <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+                <div className="flex flex-row mt-12 overflow-x-auto w-full h-[85%] ">
+                    {states.length > 0 ? (
+                        states.map((state) => (
+                            <State key={state.id} stateProps={state}/>
+                        ))
+                    ) : (
+                        <div className={"flex w-[90%] h-full items-center justify-center"}>
+                            <p className={"text-xl sm:text-2xl bg-gray-100 rounded-lg border-2 p-2"}>No states yet !</p>
+                        </div>
+                    )}
 
-                <div className="flex items-center w-full">
-                    <div
-                        className="flex items-center justify-center rounded-full 
-                        mx-4 w-16 h-16 bg-gray-100 hover:bg-gray-400 transition-colors duration-200
-                        shadow-lg cursor-pointer"
-                        onClick={() => setOpenNewStateModal(true)}
-                    >
-                        <Plus/>
+                    <div className="flex items-center w-full">
+                        <div
+                            className="flex items-center justify-center rounded-full 
+                                mx-4 w-16 h-16 bg-gray-100 hover:bg-gray-400 transition-colors duration-200
+                                shadow-lg cursor-pointer"
+                            onClick={() => setOpenNewStateModal(true)}
+                        >
+                            <Plus/>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <NewStateModal open={openNewStateModal} setOpen={setOpenNewStateModal} position={states.length}/>
+                <NewStateModal open={openNewStateModal} setOpen={setOpenNewStateModal} position={states.length}/>
+                <DragOverlay dropAnimation={null}>
+                    {activeId ? (
+                        <Card cardProps={activeCard}/>
+                    ) : null}
+                </DragOverlay>
+            </DndContext>
         </>
     )
 }


### PR DESCRIPTION
This pull request introduces drag-and-drop functionality to the card and state components using the `@dnd-kit` library. The changes include adding draggable and droppable features to the cards and states, updating the state of cards during drag events, and integrating these features into the existing components.

### Drag-and-Drop Functionality:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R13-R15): Added `@dnd-kit/core`, `@dnd-kit/sortable`, and `@dnd-kit/utilities` as dependencies to support drag-and-drop functionality.

* [`src/components/card/card.tsx`](diffhunk://#diff-8a385ea8823a8ed9f051b9b1d5663732eeb3ebfbc9c81642c817073f7154ed52R5-R6): Integrated the `useDraggable` hook from `@dnd-kit/core` to make cards draggable. Added a draggable handle using the `GripVertical` icon from `lucide-react`. [[1]](diffhunk://#diff-8a385ea8823a8ed9f051b9b1d5663732eeb3ebfbc9c81642c817073f7154ed52R5-R6) [[2]](diffhunk://#diff-8a385ea8823a8ed9f051b9b1d5663732eeb3ebfbc9c81642c817073f7154ed52R15-R47)

* [`src/components/state/state.tsx`](diffhunk://#diff-eb803acab5e8bab5b65b86858b34410d2d73ba30f08168b6fa52ac021009392dL9-R9): Integrated the `useDroppable` hook from `@dnd-kit/core` to make states droppable targets for cards. [[1]](diffhunk://#diff-eb803acab5e8bab5b65b86858b34410d2d73ba30f08168b6fa52ac021009392dL9-R9) [[2]](diffhunk://#diff-eb803acab5e8bab5b65b86858b34410d2d73ba30f08168b6fa52ac021009392dR18-R21) [[3]](diffhunk://#diff-eb803acab5e8bab5b65b86858b34410d2d73ba30f08168b6fa52ac021009392dL44-R52)

* [`src/components/statesContainer/statesContainer.tsx`](diffhunk://#diff-8128ebf45befa2d36051563f134c35711eec82d57147a0845df5f28de9275e57L5-R19): Added `DndContext` and `DragOverlay` from `@dnd-kit/core` to manage drag events and provide visual feedback during dragging. Implemented `handleDragStart` and `handleDragEnd` functions to update the state of cards when they are dragged and dropped. [[1]](diffhunk://#diff-8128ebf45befa2d36051563f134c35711eec82d57147a0845df5f28de9275e57L5-R19) [[2]](diffhunk://#diff-8128ebf45befa2d36051563f134c35711eec82d57147a0845df5f28de9275e57R29-R60) [[3]](diffhunk://#diff-8128ebf45befa2d36051563f134c35711eec82d57147a0845df5f28de9275e57R84-R89)