### PR TITLE
added project icon

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,6 +1,6 @@
 import {useContext, useEffect, useState} from "react";
 import {UserContext} from "../../context/userContext.tsx";
-import {Rocket,Bell,Users,BellDot} from "lucide-react";
+import {Rocket,Bell,Users,BellDot,FolderKanban} from "lucide-react";
 import {ProjectsModal} from "../modals/projectsModal/projectsModal.tsx";
 import {HeaderButton} from "./headerButton/headerButton.tsx";
 import {UserContainer} from "../userContainer/userContainer.tsx";
@@ -49,7 +49,7 @@ export function Header({username}: HeaderProps) {
                 </h1>
                 <div className="flex flex-row items-center justify-between gap-6">
                     <HeaderButton
-                        text={"Projects"}
+                        icon={<FolderKanban/>}
                         onClick={() => setOpenProjectModal(true)}
                     />
                     { selectedProject.id === '' ? 

--- a/src/components/modals/newCardModal/newCardModal.tsx
+++ b/src/components/modals/newCardModal/newCardModal.tsx
@@ -30,7 +30,8 @@ export function NewCardModal({open, setOpen, position}: NewCardModalProps) {
             position: position,
             title: newCardName,
             text: newCardText,
-            state_id: selectedState.id
+            state_id: selectedState.id,
+            user_card: null
         }
         await httpRequest({
             url: '/card',


### PR DESCRIPTION
This pull request includes updates to the `header` and `newCardModal` components in the project. The changes involve adding a new icon to the header and modifying the data structure for new cards.

### Header Component Updates:
* Added `FolderKanban` icon from `lucide-react` to the list of imports in `src/components/header/header.tsx`.
* Updated the `HeaderButton` in the `Header` component to use the `FolderKanban` icon instead of text for the "Projects" button.

### New Card Modal Updates:
* Modified the payload structure in the `NewCardModal` component to include a new field `user_card` set to `null` when creating a new card.